### PR TITLE
Dev tools: Enable debug mode on install

### DIFF
--- a/std_workflow_dev/js/std_workflow_debug.js
+++ b/std_workflow_dev/js/std_workflow_debug.js
@@ -13,7 +13,7 @@ P.onLoad = function() {
 P.onInstall = function() {
     if(O.PLUGIN_DEBUGGING_ENABLED) {
         // enable debugging for SUPPORT by default
-        if(!("std:enable_debugging") in O.user(3).data) {
+        if(!("std:enable_debugging" in O.user(3).data)) {
             O.user(3).data["std:enable_debugging"] = true;
         }
     }

--- a/std_workflow_dev/js/std_workflow_debug.js
+++ b/std_workflow_dev/js/std_workflow_debug.js
@@ -10,6 +10,15 @@ P.onLoad = function() {
     }
 };
 
+P.onInstall = function() {
+    if(O.PLUGIN_DEBUGGING_ENABLED) {
+        // enable debugging for SUPPORT by default
+        if(!("std:enable_debugging") in O.user(3).data) {
+            O.user(3).data["std:enable_debugging"] = true;
+        }
+    }
+};
+
 if(O.PLUGIN_DEBUGGING_ENABLED) {
 
     var showDebugTools = function() {


### PR DESCRIPTION
Enable debugging mode for SUPPORT upon install of std_workflow_dev.