### PR TITLE
Include HSVT based on toUser Group API code.

### DIFF
--- a/std_workflow/js/std_workflow_emails.js
+++ b/std_workflow/js/std_workflow_emails.js
@@ -356,7 +356,8 @@ P.globalTemplateFunction("M:switch-role", function(user) {
     var M = this.view.M;
     var haveRenderedBlock = false;
     this.getAllNamedBlockNames().forEach(function(name) {
-        // If user is a Group, checking if group is member of itself doesn't mean anything.
+        // If user is a Group, group is not member of itself so to permit group API codes to name
+        // blocks check the API code of user.
         if(M.hasRole(user, name) || (user.isGroup && user.code === name)) {
             this.writeBlock(name);
             haveRenderedBlock = true;

--- a/std_workflow/js/std_workflow_emails.js
+++ b/std_workflow/js/std_workflow_emails.js
@@ -356,7 +356,7 @@ P.globalTemplateFunction("M:switch-role", function(user) {
     var M = this.view.M;
     var haveRenderedBlock = false;
     this.getAllNamedBlockNames().forEach(function(name) {
-        if(M.hasRole(user, name)) {
+        if((user.isGroup && user.code === name) || M.hasRole(user, name)) {
             this.writeBlock(name);
             haveRenderedBlock = true;
         }

--- a/std_workflow/js/std_workflow_emails.js
+++ b/std_workflow/js/std_workflow_emails.js
@@ -356,8 +356,8 @@ P.globalTemplateFunction("M:switch-role", function(user) {
     var M = this.view.M;
     var haveRenderedBlock = false;
     this.getAllNamedBlockNames().forEach(function(name) {
-        // If user is a Group, group is not member of itself so to permit group API codes to name
-        // blocks check the API code of user.
+        // If user is a Group, hasRole() won't match as groups are not members of themselves.
+        // In this case compare against the group API code, so group roles work usefully.
         if(M.hasRole(user, name) || (user.isGroup && user.code === name)) {
             this.writeBlock(name);
             haveRenderedBlock = true;

--- a/std_workflow/js/std_workflow_emails.js
+++ b/std_workflow/js/std_workflow_emails.js
@@ -356,7 +356,8 @@ P.globalTemplateFunction("M:switch-role", function(user) {
     var M = this.view.M;
     var haveRenderedBlock = false;
     this.getAllNamedBlockNames().forEach(function(name) {
-        if((user.isGroup && user.code === name) || M.hasRole(user, name)) {
+        // If user is a Group, checking if group is member of itself doesn't mean anything.
+        if(M.hasRole(user, name) || (user.isGroup && user.code === name)) {
             this.writeBlock(name);
             haveRenderedBlock = true;
         }


### PR DESCRIPTION
We can use this for not including **Dear...** for a group part of email recipients and to include messages in email specific to them.