### PR TITLE
Fix debug mode UI for document store linking to non-debug UI

### DIFF
--- a/std_document_store_dev/template/workflow/debug/overview.hsvt
+++ b/std_document_store_dev/template/workflow/debug/overview.hsvt
@@ -23,7 +23,7 @@
   <tr>
     <td> formId </td>
     <td> formTitle </td>
-    <td> <a href=[^{path} "/admin/form/" ^{M.workUnit.id} "/" formId]>"Edit"</a> </td>
+    <td> <a href=[^{path} "/debug/form/" ^{M.workUnit.id} "/" formId]>"Edit"</a> </td>
   </tr>
   }
 </table>
@@ -48,7 +48,7 @@
   </tr>
   each(instance.history) {
   <tr>
-    <td> <a href=[^{path} "/admin/view-document/" ^{M.workUnit.id} "/" version]>version</a> </td>
+    <td> <a href=[^{path} "/debug/view-document/" ^{M.workUnit.id} "/" version]>version</a> </td>
     <td> std:date:time(date) </td>
     <td> user.name </td>
   </tr>

--- a/std_document_store_dev/template/workflow/debug/view-document.hsvt
+++ b/std_document_store_dev/template/workflow/debug/view-document.hsvt
@@ -30,7 +30,7 @@
   </tr>
   each(instance.history) {
   <tr>
-    <td> <a href=[^{path} "/admin/view-document/" ^{M.workUnit.id} "/" version]>version</a> </td>
+    <td> <a href=[^{path} "/debug/view-document/" ^{M.workUnit.id} "/" version]>version</a> </td>
     <td> std:date:time(date) </td>
     <td> user.name </td>
   </tr>

--- a/std_document_store_dev/template/workflow/form.hsvt
+++ b/std_document_store_dev/template/workflow/form.hsvt
@@ -1,0 +1,6 @@
+if(deferredPreForm) {
+  render(deferredPreForm)
+}
+<form method="POST"> std:form:token()
+  render(deferredForm)
+</form>


### PR DESCRIPTION
The templates link to `/admin/` rather than `/debug/` when using std_document_store_dev and the debug mode.

Debug UI uses underlying authenticated user to permissions, so there's a Not permitted error thrown when clicking one of these inks if the currently impersonated user doesn't have admin/permissions to edit the forms.