### PR TITLE
Dashboard list's hasColumnBasedOnFact() should consider JoinColumn definitions.

### DIFF
--- a/std_reporting/js/std_reporting_dashboard_list.js
+++ b/std_reporting/js/std_reporting_dashboard_list.js
@@ -37,6 +37,8 @@ DashboardList.prototype.hasColumnBasedOnFact = function(fact) {
         var entry = accumulator.pop();
         if(entry.fact === fact) { return true; }
         else if("columns" in entry) {
+            // Lists of columns are nested between groups and types of columns
+            // e.g. join, but we can read each column on the top of the stack.
             accumulator.push.apply(accumulator, entry.columns);
         }
     }
@@ -70,8 +72,18 @@ DashboardList.prototype._makeRenderableColumnList = function() {
     if("$removeColumnsBasedOnFact" in this) {
         var removes = this.$removeColumnsBasedOnFact;
         columns = _.filter(columns, function(column) {
-            var cfact = column.fact;
-            return !(cfact && (-1 !== removes.indexOf(cfact)));
+            var accumulator = [column];
+            while(accumulator.length > 0) {
+                var col = accumulator.shift();
+                if(col.fact && -1 !== removes.indexOf(col.fact)) {
+                    return false;
+                } else if("columns" in col) {
+                    // Columns may be still be nested due to certain types of
+                    // column e.g. join, but we can read each column in order.
+                    accumulator.splice.apply(accumulator, [0, 0].concat(col.columns));
+                }
+            }
+            return true;
         });
     }
     columns.forEach(function(c) { c._prepare(dashboard); });


### PR DESCRIPTION
I managed to avoid recursion but I'm not sure if I did that in a good way.