### PR TITLE
Add property to std:transition_form for constructing form document

### DIFF
--- a/std_workflow/js/std_workflow_transition_form.js
+++ b/std_workflow/js/std_workflow_transition_form.js
@@ -15,6 +15,7 @@ P.registerWorkflowFeature("std:transition_form", function(workflow, spec) {
     if(!form) { throw new Error("form must be specified."); }
     var onTransitionCallback = spec.onTransition;
     var prepareFormInstance = spec.prepareFormInstance;
+    var makeDocumentForInstance = spec.makeDocumentForInstance;
 
     var doNotShowForm = function(ui) {
         if(showForTransitions && (-1 === showForTransitions.indexOf(ui.requestedTransition))) {
@@ -23,6 +24,11 @@ P.registerWorkflowFeature("std:transition_form", function(workflow, spec) {
     };
 
     var getFormInstance = function(M, E, ui) {
+        if(makeDocumentForInstance) {
+            // Maintain previous behaviour by copying properties
+            // from created document into ui.transitionData
+            _.extend(ui.transitionData, makeDocumentForInstance(M));
+        }
         var instance = form.instance(ui.transitionData);
         if(prepareFormInstance) { prepareFormInstance(M, instance); }
         instance.update(E.request);


### PR DESCRIPTION
Workflows using std:transition_form can't modify the document used to create the instance.

Use case here is for pre-populating data in a form or setting data to be examined by conditional statements to decide if something should be included or not.

This PR solves it by adding makeDocumentForInstance(M) to std:transition_form specification definition. Appreciate it may not be the best solution or there may be a better naming convention to use, but think it's a useful ability to have.