### PR TITLE
Docstore and reporting minor fixes

### DIFF
--- a/std_document_store/js/docstore_viewer.js
+++ b/std_document_store/js/docstore_viewer.js
@@ -47,7 +47,8 @@ var DocumentViewer = P.DocumentViewer = function(instance, E, options) {
                 v.where("version","<",this.version);
                 if(v.length) { this.showChangesFrom = v[0].version; }
             } else {
-                if(v.length > 1) { this.showChangesFrom = v[1].version; }
+                if(instance.currentDocumentIsEdited && v.length) { this.showChangesFrom = v[0].version; }
+                else if(v.length > 1) { this.showChangesFrom = v[1].version; }
             }
         } else {
             this.showChangesFrom = parseInt(E.request.parameters.from, 10);

--- a/std_reporting/js/std_reporting_dashboard_list.js
+++ b/std_reporting/js/std_reporting_dashboard_list.js
@@ -384,7 +384,7 @@ var refPersonNameColumnFieldsFn = function(r) {
         fields.url = object.url();
         return fields;
     } else {
-        return {url:object.url(), last:title.toString()};
+        return {url:object.url(), last:title ? title.toString() : "????"};
     }
 };
 


### PR DESCRIPTION
Docstore: when viewing changes on an edited document, use the last committed document as the comparison, not second to last.
Reporting: where an object doesn't have a title, use ????, don't exception.