### PR TITLE
row_text_filter reporting feature only includes the first title of an object for search matching

### DIFF
--- a/std_reporting/js/std_reporting_dashboard_list.js
+++ b/std_reporting/js/std_reporting_dashboard_list.js
@@ -199,7 +199,16 @@ P.registerReportingFeature("std:row_text_filter", function(dashboard, spec) {
         dashboard.$rowAttributeFns.push(function(row, attrs) {
             attrs['data-text-filter'] = facts.map(function(fact) {
                 var value = row[fact], factType = dashboard.collection.$factType[fact];
-                if(factType === "ref") { return (value === null) ? '' : value.load().title; }
+                if(factType === "ref") {
+                    if(value === null) { return ''; }
+                    else {
+                        if(spec.useAllTitlesForRefColumns) {
+                            return value.load().everyTitle().join(' ');
+                        } else {
+                            return value.load().title;
+                        }
+                    }
+                }
                 return (value === null) ? '' : value.toString();
             }).join(' ').toLowerCase();
         });


### PR DESCRIPTION
std:row_text_filter only takes the first title of an object when specifying Ref type columns to use for the search.

Real world example use case where this has been a small problem: Countries, if you have a 'United Kingdom' country object with an alternate title 'GB', you can't search 'GB' on the dashboard and find United Kingdom.

Appreciate it's possible for developers to define their own implementation of std:row_text_filter on a different name to achieve this, but felt like it might be something that Haplo would be interested in for the standard feature.

I wrote a small commit, which adds a `useAllTitlesForRefColumns` property, so current default behaviour is preserved (better names welcome!), but when this property is true, we use .everyTitle() to add all titles to the filter text rather than just the first.

Usage example:

        use("std:row_text_filter", {
            facts:["country"], 
            useAllTitlesForRefColumns: true,
            placeholder:"Search..."
        }).