### PR TITLE
Combined Timeline Distinct Titles

### DIFF
--- a/std_workflow/js/std_workflow_ui.js
+++ b/std_workflow/js/std_workflow_ui.js
@@ -213,8 +213,8 @@ _.extend(P.WorkflowInstanceBase.prototype, {
 P.implementService("std:workflow:deferred_render_combined_timeline", function(instances) {
     var entries = [];
     _.each(instances, function(M) {
-        var distinctProcessName = M.workflowServiceMaybe("std:workflow:combined_timeline:title_for_instance");
-        var processName = distinctProcessName || M.getWorkflowProcessName();
+        var instanceProcessName = M.workflowServiceMaybe("std:workflow:combined_timeline:title_for_instance");
+        var processName = instanceProcessName || M.getWorkflowProcessName();
         var renderedEntries = M._renderTimelineEntries(M.timelineSelect());
         renderedEntries.forEach(function(e) { e.processName = processName; });
         entries = entries.concat(renderedEntries);

--- a/std_workflow/js/std_workflow_ui.js
+++ b/std_workflow/js/std_workflow_ui.js
@@ -213,7 +213,8 @@ _.extend(P.WorkflowInstanceBase.prototype, {
 P.implementService("std:workflow:deferred_render_combined_timeline", function(instances) {
     var entries = [];
     _.each(instances, function(M) {
-        var processName = M.getWorkflowProcessName();
+        var distinctProcessName = M.workflowServiceMaybe("std:workflow:combined_timeline:title_for_instance");
+        var processName = distinctProcessName || M.getWorkflowProcessName();
         var renderedEntries = M._renderTimelineEntries(M.timelineSelect());
         renderedEntries.forEach(function(e) { e.processName = processName; });
         entries = entries.concat(renderedEntries);


### PR DESCRIPTION
Sometimes when workflows are repeated we need to set slightly different workflow process names so that the combined timeline doesn't group them under 1 title which can be confusing.

I've added a workflow service to implement to return the distinct title.