### PR TITLE
Fix auto move user for workflows of same work type and ref

### DIFF
--- a/std_workflow/js/std_workflow_auto_move_user.js
+++ b/std_workflow/js/std_workflow_auto_move_user.js
@@ -87,7 +87,7 @@ P.backgroundCallback("update_actionableby", function(data) {
         _.each(O.work.query().isOpen().tag(ref.toString()+'.ABD',"t"), function(workUnit) {
             var workflow = P.allWorkflows[workUnit.workType];
             if(workflow) {
-                var M = workflow.instanceForRef(workUnit.ref);
+                var M = workflow.instance(workUnit);
                 var currentActionableById = workUnit.actionableBy.id;
                 var actionableByName = M._findCurrentActionableByNameFromStateDefinitions();
                 if(actionableByName) {


### PR DESCRIPTION
I got unnecessary AUTOMOVE timeline entries when opening multiple workflows of the same work type about the same object. Hopefully this fixes it nicely.