### PR TITLE
Added 'priority' to `dashboard.display()`

### DIFF
--- a/std_reporting/js/std_reporting_dashboards.js
+++ b/std_reporting/js/std_reporting_dashboards.js
@@ -167,16 +167,18 @@ P.Dashboard.prototype.calculateStatistic = function(statistic, displayOptions) {
     });
 };
 
-P.Dashboard.prototype.display = function(where, deferred) {
+P.Dashboard.prototype.display = function(where, deferred, priority) {
     if(!deferred) { return; }
     if(!where) { where = "above"; }
+    if(priority === null || priority === undefined) { priority = 0; }
     if(!O.isDeferredRender(deferred)) {
         throw new Error("Second argument to where() must be a deferred render.");
     }
     var displays = this.$displays;
     if(!displays) { displays = this.$displays = {}; }
     if(!(where in displays)) { displays[where] = []; }
-    displays[where].push(deferred);
+    displays[where].push({ deferred: deferred, priority: priority });
+    displays[where] = _.sortBy(displays[where], 'priority');
     return this;
 };
 

--- a/std_reporting/template/dashboard/aggregate/aggregate_dashboard.hsvt
+++ b/std_reporting/template/dashboard/aggregate/aggregate_dashboard.hsvt
@@ -6,17 +6,17 @@ template:dashboard:common:dashboard-page() {
     std:ui:notice(i("This dashboard does not include all data. Some rows are omitted."))
   }
   
-  each(dashboard.$displays.above-export) { render(.) }
+  each(dashboard.$displays.above-export) { render(deferred) }
 
   template:dashboard:common:export-form() {
 
-    each(dashboard.$displays.above-navigation) { render(.) }
+    each(dashboard.$displays.above-navigation) { render(deferred) }
   
     template:dashboard:common:navigation()
 
-    each(dashboard.$displays.above) { render(.) }
+    each(dashboard.$displays.above) { render(deferred) }
 
-    each(dashboard.$displays.above-table) { render(.) }
+    each(dashboard.$displays.above-table) { render(deferred) }
 
     template:dashboard:aggregate:aggregate-table()
   }

--- a/std_reporting/template/dashboard/common/dashboard-page.hsvt
+++ b/std_reporting/template/dashboard/common/dashboard-page.hsvt
@@ -14,10 +14,10 @@ if(dashboard.invalidFactsAtRequested) {
   std:ui:notice(i("Invalid time requested, showing current data."))
 }
 
-each(dashboard.$displays.above-summary) { render(.) }
+each(dashboard.$displays.above-summary) { render(deferred) }
 
 template:dashboard:common:summary-display()
 
 yield()
 
-each(dashboard.$displays.below) { render(.) }
+each(dashboard.$displays.below) { render(deferred) }

--- a/std_reporting/template/dashboard/list/list_dashboard.hsvt
+++ b/std_reporting/template/dashboard/list/list_dashboard.hsvt
@@ -2,15 +2,15 @@ std:plugin:resources("tablesort.js")
 
 template:dashboard:common:dashboard-page() {
 
-  each(dashboard.$displays.above-export) { render(.) }
+  each(dashboard.$displays.above-export) { render(deferred) }
 
   template:dashboard:common:export-form() {
 
-    each(dashboard.$displays.above-navigation) { render(.) }
+    each(dashboard.$displays.above-navigation) { render(deferred) }
   
     template:dashboard:common:navigation()
   
-    each(dashboard.$displays.above) { render(.) }
+    each(dashboard.$displays.above) { render(deferred) }
   
     if(widgetsTop) {
       <div class="z__std_reporting_list_widgets_top">
@@ -19,7 +19,7 @@ template:dashboard:common:dashboard-page() {
     }
   }
 
-  each(dashboard.$displays.above-table) { render(.) }
+  each(dashboard.$displays.above-table) { render(deferred) }
 
   <table id="z__std_reporting_list_filterable_table" class=[
         "tablesort"


### PR DESCRIPTION
This allows users to specify in which order
multiple deferreds are rendered in when they cannot control the order
in which services are called to add them