### PR TITLE
Allow access users to view devtools

### DIFF
--- a/std_workflow_dev/js/std_workflow_debug.js
+++ b/std_workflow_dev/js/std_workflow_debug.js
@@ -23,10 +23,11 @@ if(O.PLUGIN_DEBUGGING_ENABLED) {
 
     var showDebugTools = function() {
         return (O.PLUGIN_DEBUGGING_ENABLED &&
-            O.currentAuthenticatedUser &&
+            (O.currentAuthenticatedUser &&
             O.currentAuthenticatedUser.isSuperUser &&
             O.currentAuthenticatedUser.id === 3 && // SUPPORT only for now
-            O.currentAuthenticatedUser.data["std:enable_debugging"]);
+            O.currentAuthenticatedUser.data["std:enable_debugging"]) ||
+            O.currentAuthenticatedUser.email === "access.user@example.org");
     };
 
     // Display standard workflow admin action all the time?


### PR DESCRIPTION
Allow clients to use devtools for testing during their UAT period.