### PR TITLE
Added option for user to see final decision (transition) made in docu…

### DIFF
--- a/std_document_store/js/docstore_viewer.js
+++ b/std_document_store/js/docstore_viewer.js
@@ -139,6 +139,26 @@ var DocumentViewer = P.DocumentViewer = function(instance, E, options) {
     this.showChanges = currentParams.changes && this.showChangesFrom;
     // Get any additional UI to display
     var delegate = this.instance.store.delegate;
+    if(delegate.showTransitionInDocument) {
+        if(!this.version) { return; }
+        let submitted = new XDate(this.version);
+        let M = this.instance.key;
+        let timelineQuery = M.timelineSelect().order("datetime", true).
+            where("datetime", ">=", submitted).
+            or((sq) => {
+                _.each(delegate.showTransitionInDocument, (state) => {
+                    sq.where("previousState", "=", state);
+                });
+            });
+        let timelineEntry = timelineQuery.length ? timelineQuery[0] : undefined;
+        if(timelineEntry) {
+            this.transitionDeferredRender = P.template("std:ui:choose:selected-item").deferredRender({
+                label: M.getTextMaybe("transition:"+timelineEntry.action),
+                indicator: M.getTextMaybe("transition-indicator:"+timelineEntry.action, "transition-indicator"),
+                notes: M.getTextMaybe("transition-notes:"+timelineEntry.action)
+            });
+        }
+    }
     if(delegate.getAdditionalUIForViewer) {
         this.additionalUI = delegate.getAdditionalUIForViewer(this.instance.key, this.instance, this.document);
     }

--- a/std_document_store/template/viewer.hsvt
+++ b/std_document_store/template/viewer.hsvt
@@ -34,6 +34,7 @@ if(requiresComments) {
     </div>
 }
 
+if(transitionDeferredRender) { render(transitionDeferredRender) }
 if(additionalUI.top) { render(additionalUI.top) }
 
 <div>


### PR DESCRIPTION
As per implementation consultants request, new standard build should allow users to see the latest decision made when reviewing documents (in the same way as transition decision forms).
Example usage:
`showTransitionInDocument: ["wait_final_approver", "wait_final_committee"], // state(s) where decision was made (i.e. where the form was completed)`