### PR TITLE
Docstore comment permissions

### DIFF
--- a/std_document_store/js/docstore_comments.js
+++ b/std_document_store/js/docstore_comments.js
@@ -93,7 +93,7 @@ P.implementService("std:document_store:comments:respond", function(E, docstore, 
         });
         //attempt to omit users (for name display) if deny is specified and spec is matched (no real use at the moment for this to be additive), otherwise allow all names to be viewed
         if(!checkPermissions(key, "viewCommenterName")) {
-            _.each(docstore.delegate.viewCommenterName, obj => {
+            _.each(docstore.delegate.viewCommenterName, function(obj) {
                 if(obj.action === "deny") {
                     var currentUserMatchesRoleMaybe = (!obj.roles || !obj.roles.length) ? true : key.hasAnyRole(O.currentUser, obj.roles);
                     var isSelectedMaybe = obj.selector ? key.selected(obj.selector) : true;
@@ -111,8 +111,8 @@ P.implementService("std:document_store:comments:respond", function(E, docstore, 
                                 }
                                 return commenterRoles;
                             };
-                            _.each(_.keys(users), k => {
-                                _.each(obj.commenter, commenterRole => {
+                            _.each(_.keys(users), function(k) {
+                                _.each(obj.commenter, function(commenterRole) {
                                     if(key.hasRole(O.securityPrincipal(parseInt(k)), commenterRole)) {
                                         if(obj.replacementRoleNames && obj.replacementRoleNames[commenterRole]) {
                                             setRoleNames(k, obj.replacementRoleNames[commenterRole]);
@@ -126,7 +126,7 @@ P.implementService("std:document_store:comments:respond", function(E, docstore, 
                             });
                             // This (.join(/)) isn't that useful unless we can pass all entities that can comment explicitly
                             // The only case in which it would be useful was if "commenter" had multiple roles in held by one person
-                            _.each(commenterRoles, (roleNames, userId) => {
+                            _.each(commenterRoles, function(roleNames, userId) {
                                 users[userId] = _.uniq(roleNames).join("/");
                             });
                         }
@@ -201,14 +201,19 @@ var checkAdditionalCommentPermissions = function(M, permissionsSpec, commentRow,
     // deny if explicit action stated, otherwise treat matching specs that contain commentFlag rules but no matching commentFlag on the comment as deny permissions but only if all other parts of spec also match
     var shouldDeny = _.chain(permissionsSpec).
         clone().
-        filter(v => ((v.action === "deny") || (!!v.commentFlags ? hasValidSelectorOrRole(v, commentRow) && !checkCommentFlags(v, commentRow) : false))).
+        filter(function(v) {
+            return ((v.action === "deny") ||
+                (!!v.commentFlags ? hasValidSelectorOrRole(v, commentRow) && !checkCommentFlags(v, commentRow) : false));
+        }).
         value();
     var shouldAllow = _.chain(permissionsSpec).
         clone().
         difference(shouldDeny).
-        any(v => hasValidSelectorOrRole(v, commentRow) && checkCommentFlags(v, commentRow) && checkPrivacyPermissionsForRow(M, commentRow)).
+        any(function(v) {
+            return hasValidSelectorOrRole(v, commentRow) && checkCommentFlags(v, commentRow) && checkPrivacyPermissionsForRow(M, commentRow);
+        }).
         value();
-    shouldDeny = _.any(shouldDeny, d => hasValidSelectorOrRole(d, commentRow));
+    shouldDeny = _.any(shouldDeny, function(d) { return hasValidSelectorOrRole(d, commentRow); });
     return shouldAllow && !shouldDeny;
 };
 

--- a/std_document_store/js/docstore_comments.js
+++ b/std_document_store/js/docstore_comments.js
@@ -54,7 +54,8 @@ P.implementService("std:document_store:comments:respond", function(E, docstore, 
             // i.e. has been edited by another user
             if(rowProperties.userId !== O.currentUser.id) {
                 rowProperties.lastEditedBy = O.currentUser.id;
-                rowProperties.lastEditedByName = O.currentUser.name;
+            } else if(oldCommentRow && oldCommentRow.lastEditedBy) {
+                rowProperties.lastEditedBy = oldCommentRow.lastEditedBy;
             }
             var row = docstore.commentsTable.create(rowProperties);
             row.save();
@@ -103,10 +104,14 @@ P.implementService("std:document_store:comments:respond", function(E, docstore, 
                         } else {
                             var commenterRoles = {};
                             var setRoleNames = function(userId, newDisplayName) {
-                                commenterRoles[userId] = commenterRoles[userId] ? commenterRoles[userId].push(newDisplayName) : [newDisplayName];
+                                if(commenterRoles[userId]) {
+                                    commenterRoles[userId].push(newDisplayName);
+                                } else {
+                                    commenterRoles[userId] = [newDisplayName];
+                                }
                                 return commenterRoles;
                             };
-                            _.every(_.clone(users), (v, k) => {
+                            _.each(_.keys(users), k => {
                                 _.each(obj.commenter, commenterRole => {
                                     if(key.hasRole(O.securityPrincipal(parseInt(k)), commenterRole)) {
                                         if(obj.replacementRoleNames && obj.replacementRoleNames[commenterRole]) {
@@ -150,7 +155,7 @@ var rowForClient = function(row, key, checkPermissions, lastTransitionTime, dele
             isPrivate: row.isPrivate,
             currentUserCanEdit: currentUserCanEditComment(row, key, checkPermissions, lastTransitionTime, delegate.editCommentsOtherUsers),
             currentUserCanView: currentUserCanViewComment(row, key, checkPermissions, lastTransitionTime, delegate.viewCommentsOtherUsers),
-            lastEditedBy: row.lastEditedByName
+            lastEditedBy: row.lastEditedBy ? O.user(row.lastEditedBy).name : undefined
         };
     }
 };

--- a/std_document_store/js/docstore_comments.js
+++ b/std_document_store/js/docstore_comments.js
@@ -92,7 +92,9 @@ P.implementService("std:document_store:comments:respond", function(E, docstore, 
                 users[uid] = O.user(uid).name;
             }
         });
-        response.users = users;
+        if(checkPermissions(key, "viewCommenterName")) {
+            response.users = users;
+        }
         response.forms = forms;
     }
 

--- a/std_document_store/js/docstore_comments.js
+++ b/std_document_store/js/docstore_comments.js
@@ -31,7 +31,7 @@ P.implementService("std:document_store:comments:respond", function(E, docstore, 
             var oldCommentQ = docstore.commentsTable.select().where("id", "=", parseInt(supersedesId, 10));
             if(oldCommentQ.length) {
                 oldCommentRow = oldCommentQ[0];
-                userCanEditComment = currentUserCanEditComment(oldCommentRow, key, checkPermissions, lastTransitionTime, docstore.delegate, docstore.delegate.alwaysEditOwnComments);
+                userCanEditComment = currentUserCanEditComment(oldCommentRow, key, checkPermissions, lastTransitionTime, docstore.delegate.editCommentsOtherUsers, docstore.delegate.alwaysEditOwnComments);
             }
         }
         if(supersedesId && !userCanEditComment) {
@@ -126,8 +126,8 @@ P.implementService("std:document_store:comments:respond", function(E, docstore, 
                             });
                             // This (.join(/)) isn't that useful unless we can pass all entities that can comment explicitly
                             // The only case in which it would be useful was if "commenter" had multiple roles in held by one person
-                            _.each(commenterRoles, (newDisplayText, userId) => {
-                                users[userId] = (newDisplayText.length > 1 && !obj.onlyDisplayFirstReplacementRoleName) ? newDisplayText.join("/") : newDisplayText[0];
+                            _.each(commenterRoles, (roleNames, userId) => {
+                                users[userId] = _.uniq(roleNames).join("/");
                             });
                         }
                     }

--- a/std_document_store/js/docstore_comments.js
+++ b/std_document_store/js/docstore_comments.js
@@ -127,7 +127,7 @@ P.implementService("std:document_store:comments:respond", function(E, docstore, 
                             // This (.join(/)) isn't that useful unless we can pass all entities that can comment explicitly
                             // The only case in which it would be useful was if "commenter" had multiple roles in held by one person
                             _.each(commenterRoles, (newDisplayText, userId) => {
-                                users[userId] = newDisplayText.length > 1 ? newDisplayText.join("/") : newDisplayText[0];
+                                users[userId] = (newDisplayText.length > 1 && !obj.onlyDisplayFirstReplacementRoleName) ? newDisplayText.join("/") : newDisplayText[0];
                             });
                         }
                     }

--- a/std_document_store/js/docstore_comments.js
+++ b/std_document_store/js/docstore_comments.js
@@ -198,7 +198,6 @@ var checkAdditionalCommentPermissions = function(M, permissionsSpec, commentRow,
     //Omitting these objects or specifying an empty list [] means that everyone has permission.
     //if no viewCommentsOtherUsers check privacy since the select filtering seems to break things
     if(!permissionsSpec.length) { return checkPrivacyPermissionsForRow(M, commentRow); }
-    //TODO: clean up the logic for this
     // deny if explicit action stated, otherwise treat matching specs that contain commentFlag rules but no matching commentFlag on the comment as deny permissions but only if all other parts of spec also match
     var shouldDeny = _.chain(permissionsSpec).
         clone().
@@ -215,10 +214,7 @@ var checkAdditionalCommentPermissions = function(M, permissionsSpec, commentRow,
 
 var currentUserCanEditComment = function(commentRow, M, checkPermissions, lastTransitionTime, editCommentsOtherUsers) {
     if(checkPermissions(M, 'editComments') && O.currentUser.id === commentRow.userId) {
-        // as below, will removing this cause issues?
-        // if(lastTransitionTime < commentRow.datetime) {
             return true;
-        // }
     } else if(editCommentsOtherUsers) {
         return checkAdditionalCommentPermissions(M, editCommentsOtherUsers, commentRow, checkPermissions);
     }
@@ -226,10 +222,7 @@ var currentUserCanEditComment = function(commentRow, M, checkPermissions, lastTr
 
 var currentUserCanViewComment = function(commentRow, M, checkPermissions, lastTransitionTime, viewCommentsOtherUsers) {
     if(O.currentUser.id === commentRow.userId) {
-        //will removing this break anything IRL? It seems to hinder viewing your own comments if there has been no change in state
-        // if(lastTransitionTime < commentRow.datetime) {
             return true;
-        // }
     } else {
         return checkAdditionalCommentPermissions(M, viewCommentsOtherUsers, commentRow, checkPermissions);
     }

--- a/std_document_store/js/docstore_store.js
+++ b/std_document_store/js/docstore_store.js
@@ -50,7 +50,8 @@ var DocumentStore = P.DocumentStore = function(P, delegate) {
             comment:      { type:"text" },
             isPrivate:    { type:"boolean", nullable:true }, // may be null if private comments aren't enabled
             // supersededBy only set if the comment was edited
-            supersededBy: { type:"int", nullable:true}
+            supersededBy: { type:"int", nullable:true},
+            commentFlags: { type:"json", nullable:true}
         });
         this.commentsTable = P.db[commentsDbName];
     }

--- a/std_document_store/js/docstore_store.js
+++ b/std_document_store/js/docstore_store.js
@@ -51,7 +51,8 @@ var DocumentStore = P.DocumentStore = function(P, delegate) {
             isPrivate:    { type:"boolean", nullable:true }, // may be null if private comments aren't enabled
             // supersededBy only set if the comment was edited
             supersededBy: { type:"int", nullable:true},
-            commentFlags: { type:"json", nullable:true}
+            commentFlags: { type:"json", nullable:true},
+            lastEditedBy: { type:"int", nullable:true }
         });
         this.commentsTable = P.db[commentsDbName];
     }

--- a/std_document_store/js/docstore_workflow.js
+++ b/std_document_store/js/docstore_workflow.js
@@ -49,7 +49,11 @@ const DEFAULT_COMMENT_IS_PRIVATE = !O.application.config["std_document_store:com
 //    addComment: [{roles:[],selector:{}}, ...] - OPTIONAL, when a user can comment on the forms
 //    viewComments: [{roles:[],selector:{}}, ...] - OPTIONAL, when a user can view the comments
 //    viewCommentsOtherUsers: [{roles:[],selector:{}}, ...] - OPTIONAL, when a user can view the 
-//              comments of other users. Defaults to same value as viewComments.
+//              comments of other users. Defaults to same value as viewComments. Has an additional property
+//               @commenter@ avaliable to specify comment author role for more specific permissions - uses array value.
+//    editCommentsOtherUsers: [{roles:[],selector:{}}, ...] - OPTIONAL, when a user can edit the 
+//              comments of other users. Has an additional property @commenter@ avaliable to specify comment
+//                author role for more specific permissions - uses array value.
 //    hideCommentsWhen: selector - OPTIONAL, defaults to {closed:true}
 
 // ----------------------------------------------------------------------------

--- a/std_document_store/js/docstore_workflow.js
+++ b/std_document_store/js/docstore_workflow.js
@@ -588,6 +588,8 @@ P.workflow.registerWorkflowFeature("std:document_store", function(workflow, spec
         var checkPermissions = function(M, action) {
             if((action === "viewCommentsOtherUsers") && !spec.viewCommentsOtherUsers) {
                 action = "viewComments";
+            } else if((action === "viewCommenterName") && !spec.viewCommenterName) {
+                action = "viewComments";
             } else if(action === "viewPrivateComments") {
                 if(spec.viewPrivateComments) {
                     return spec.viewPrivateComments(M, O.currentUser);

--- a/std_document_store/js/docstore_workflow.js
+++ b/std_document_store/js/docstore_workflow.js
@@ -54,6 +54,8 @@ const DEFAULT_COMMENT_IS_PRIVATE = !O.application.config["std_document_store:com
 //    editCommentsOtherUsers: [{roles:[],selector:{}}, ...] - OPTIONAL, when a user can edit the 
 //              comments of other users. Has an additional property @commenter@ avaliable to specify comment
 //                author role for more specific permissions - uses array value.
+//    alwaysEditOwnComments: true - OPTIONAL, when users can always edit their own comments, defaults to only
+//              allowing users to edit their own comments before the state changes
 //    hideCommentsWhen: selector - OPTIONAL, defaults to {closed:true}
 
 // ----------------------------------------------------------------------------

--- a/std_document_store/static/comments.css
+++ b/std_document_store/static/comments.css
@@ -87,6 +87,11 @@
     line-height: 14px;
 }
 
+.z__docstore_last_edited_by {
+    text-align: right;
+    padding-top: 4px;
+}
+
 .z__docstore_edit_comment_link a {
     color: #888;
 }

--- a/std_document_store/static/comments.js
+++ b/std_document_store/static/comments.js
@@ -124,14 +124,13 @@
                         $('div[data-uname]').each(function() {
                             if($('div[data-uname]',this).length) {
                                 containers.push(this);
-                            } else {
-                                // if not showing changes, need to hide if no comments
-                                if($('.z__docstore_comment_container',this).length === 0 && !showingChanges) {
-                                    $(this).hide();
-                                // if showing changes, need to un hide if has comments
-                                } else if ($('.z__docstore_comment_container',this).length !== 0 && showingChanges) {
-                                    $(this).show();
-                                }
+                            }
+                            // if not showing changes, need to hide if no comments
+                            if($('.z__docstore_comment_container',this).length === 0 && !showingChanges) {
+                                $(this).hide();
+                            // if showing changes, need to un hide if has comments
+                            } else if ($('.z__docstore_comment_container',this).length !== 0 && showingChanges) {
+                                $(this).show();
                             }
                         });
                         // Now go through the containers, and if there's nothing visible within the container, hide it entirely.

--- a/std_document_store/static/comments.js
+++ b/std_document_store/static/comments.js
@@ -66,11 +66,14 @@
                 messageDiv += _.map(_.compact([privateMsg, versionMsg]), _.escape).join('<br>');
                 header.append(messageDiv);
             }
-            if(canEdit) {
-                var footer = $('<div class="z__docstore_comment_footer"></div>');
-                footer.append('<div class="z__docstore_edit_comment_link"><a href="#"><i>Edit comment...</i></a></div>');
-                div.append(footer);
+            var footer = $('<div class="z__docstore_comment_footer"></div>');
+            if(comment.lastEditedBy) {
+                footer.append('<div class="z__docstore_last_edited_by"><i>Last edited by '+comment.lastEditedBy+'</i></div>');
             }
+            if(canEdit) {
+                footer.append('<div class="z__docstore_edit_comment_link"><a href="#"><i>Edit comment...</i></a></div>');
+            }
+            div.append(footer);
             if(insertAtTop) {
                 var existingComments = $('.z__docstore_comment_container', element);
                 if(existingComments.length) {

--- a/std_document_store/static/comments.js
+++ b/std_document_store/static/comments.js
@@ -102,8 +102,10 @@
                     _.each(data.forms, function(elements, formId) {
                         _.each(elements, function(comments, uname) {
                             _.each(comments, function(comment) {
-                                displayComment(formId, uname, comment);
-                                hasCommentsToDisplay = true;
+                                if(comment.currentUserCanView) {
+                                    displayComment(formId, uname, comment);
+                                    hasCommentsToDisplay = true;
+                                }
                             });
                         });
                     });


### PR DESCRIPTION
Please review my last commit (fe609f9b50ef5c52e351c0730841a55ede74b26a).
Everything else has already been reviewed by Jenny. The branch will not be merged in until everything Rachel did has been tested again as there as some [known issues with this for UEA](https://cayuse.atlassian.net/browse/PHDM-1247?search_id=e8019394-f96b-401f-bc80-2e3c1794f870).

The issue:
When 'show comments', 'show changes' AND 'filter questions' are selected in the document view, any questions within containers (e.g. questions within repeating sections, file uploads) that have a comment but NO changes, were not showing.

This was happening because the container is not visible due to not having any changes and the code that should make elements with comments visible was only setting the actual element as visible and not the container.

The fix:
Check if all elements, including containers, should be visible.

I am not convinced that there is any need to check whether an element is a container or not as I can't see that this is doing anything. I have left the code in just in case however.

Please let me know if you would like a demo of this.
Dev system: https://dev7a17.infomanaged.co.uk
I have also tested this in a couple of other dev systems for other clients. I think it would be worth you doing the same to make sure this doesn't break anything.