### PR TITLE
Workflow emails: add M:entity-attribute template function

### DIFF
--- a/std_workflow/js/std_workflow_emails.js
+++ b/std_workflow/js/std_workflow_emails.js
@@ -315,6 +315,14 @@ P.globalTemplateFunction("M:entity-list", function(entityName) {
     templateFunctionRenderList(this, M.entities[entityName+"_list"]);
 });
 
+P.globalTemplateFunction("M:entity-attribute", function(entityName, attributeName) {
+    var M = this.view.M;
+    var entity = M.entities[entityName+'_maybe'];
+    if(entity && attributeName in ATTR) {
+        templateFunctionRenderList(this, entity.every(ATTR[attributeName]));
+    }
+});
+
 var templateFunctionRenderList = function(t, items) {
     var strings = _.map(_.compact(items), function(item) {
         if(typeof(item) === "string") {

--- a/std_workflow/template/admin/full-info.hsvt
+++ b/std_workflow/template/admin/full-info.hsvt
@@ -1,4 +1,4 @@
-pageTitle("Timeline: " M.title)
+pageTitle("Full info: " M.title)
 backLink(M.url)
 
 <p> "Work type: " workUnit.workType </p>

--- a/std_workflow_dev/template/workflow-notifications.hsvt
+++ b/std_workflow_dev/template/workflow-notifications.hsvt
@@ -11,13 +11,15 @@ unless(notifications.length) {
                 <th> "Test?" </th>
             </tr>
             each(notifications) {
-                <td style="width:100px"> name </td>
-                <td>
-                    <input type="submit" name="notification" value=["Test send: " name]> // value must end with ': <name of notification>'
-                    if(testSend) {
-                        " (email sent)"
-                    }
-                </td>
+                <tr>
+                    <td style="width:100px"> name </td>
+                    <td>
+                        <input type="submit" name="notification" value=["Test send: " name]> // value must end with ': <name of notification>'
+                        if(testSend) {
+                            " (email sent)"
+                        }
+                    </td>
+                </tr>
             }
         </table>
     </form>


### PR DESCRIPTION
New template function to cut down on attribute lookups in JS when preparing notifications.
e.g. instead of passing { studentId: M.entities.researcher.first(A.StudentId) } in a notification view, instead add this straight to the hsvt:
`M:entity-attribute("researcher" "hres:attribute:student-id")`
(should give a comma separated list if there's more than one value for an attribute, or a blank space if there's nothing)

Expected outputs:
`M:entity-attribute("researcher" "hres:attribute:student-id")` -> ID value as string
`M:entity-attribute("project" "hres:attribute:supervisor")` -> comma separated list of names
`M:entity-attribute("researcher" "hres:attribute:supervisor")` -> nothing, no such values on the entity object
`M:entity-attribute("nobody" "hres:attribute:student-id")` -> nothing, no such entity

Additional clean-up in Workflow admin: correct 'full info' page title (incorrectly labelled 'Timeline') and add missing tags in notification test table so each notification is on its own row.