### PR TITLE
Docstore: add currentDocumentView and lastCommittedDocumentView

### DIFF
--- a/std_document_store/js/docstore_instance.js
+++ b/std_document_store/js/docstore_instance.js
@@ -261,6 +261,21 @@ DocumentInstance.prototype._selectedFormInfo = function(document, selectedFormId
     };
 };
 
+// Return a copy of the document with values replaced by display names where appropriate
+DocumentInstance.prototype._makeDocumentView = function(document) {
+    var delegate = this.store.delegate;
+    var key = this.key;
+    var forms = this.forms;
+    _.each(forms, function(form) {
+        var formInstance = form.instance(document);
+        if(delegate.prepareFormInstance) {
+            delegate.prepareFormInstance(key, form, formInstance, "document");
+        }
+        document = formInstance.makeView(document);
+    });
+    return document;
+};
+
 DocumentInstance.prototype.__defineGetter__("lastCommittedDocumentHTML", function() {
     return this._renderDocument(this.lastCommittedDocument);
 });
@@ -274,6 +289,13 @@ DocumentInstance.prototype.__defineGetter__("currentDocumentHTML",       functio
 DocumentInstance.prototype.deferredRenderCurrentDocument = function() {
     return this._renderDocument(this.currentDocument, true);
 };
+
+DocumentInstance.prototype.__defineGetter__("lastCommittedDocumentView", function() {
+    return this._makeDocumentView(this.lastCommittedDocument);
+});
+DocumentInstance.prototype.__defineGetter__("currentDocumentView",       function() {
+    return this._makeDocumentView(this.currentDocument);
+});
 
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
… getters for retrieving documents with display values substituted in by makeView.

```
let instance = EgWorkflow.documentStore.applicationForm.instance(M);
console.log("lastCommittedDocument:", instance.lastCommittedDocument); // document.reason: 'exampleReason1'
console.log("displayDocument:", instance.lastCommittedDocumentView);   // document.reason: 'Reason #1'
```